### PR TITLE
Add different vibrate levels for different peg types

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -116,7 +116,7 @@ namespace PeglinCore
                     break;
                 case Peg.PegType.CRIT:      // Yellow crit peg
                     Log.LogDebug("CRIT");
-                    RunVibrate(0.9);
+                    RunVibrate(0.8);
                     break;
                 case Peg.PegType.DULL:      // I think these are the gray pegs that don't pop on hit, from certain enemies
                     Log.LogDebug("DULL");

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -7,6 +7,7 @@ using Buttplug.Client.Connectors.WebsocketConnector;
 using System.Timers;
 using System.Threading.Tasks;
 using UnityEngine;
+using Battle;
 
 namespace PeglinCore
 {
@@ -27,6 +28,7 @@ namespace PeglinCore
             Log = base.Logger;
             Log.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
             client = new ButtplugClient("Pegginglin");
+            Peg.OnPegHit += HandlePegHit;       // Adds event handler for peg hits
             
             Task.Run(async () => {
                 while (true)
@@ -83,11 +85,9 @@ namespace PeglinCore
             timer.Stop();
         }
 
-
-        [HarmonyPatch(typeof(RegularPeg), "PopPeg")]
-        [HarmonyPostfix]
-        static private void PatchCollided()
+        static void RunVibrate(double value)
         {
+            Log.LogDebug("RunVibrate called with value: " + value);
             if (!timer.Enabled)
             {
                 if (client.Devices != null)
@@ -96,7 +96,8 @@ namespace PeglinCore
                     {
                         if (d.VibrateAttributes.Count > 0)
                         {
-                            d.VibrateAsync(1.0);
+                            Log.LogDebug("Successfully reached actual Vibrate trigger");
+                            d.VibrateAsync(value);
                         }
                     }
                 }
@@ -105,5 +106,62 @@ namespace PeglinCore
             timer.Stop();
             timer.Start();
         }
+
+        static private void EvaluatePeg(Peg peg, Peg.PegType pegType)
+        {
+            switch (pegType)
+            {
+                case Peg.PegType.REGULAR:   // Regular peg
+                    RunVibrate(0.4);
+                    break;
+                case Peg.PegType.CRIT:      // Yellow crit peg
+                    Log.LogDebug("CRIT");
+                    RunVibrate(0.8);
+                    break;
+                case Peg.PegType.DULL:      // I think these are the gray pegs that don't pop on hit, from certain enemies
+                    Log.LogDebug("DULL");
+                    RunVibrate(0.3);
+                    break;
+                case Peg.PegType.BOUNCER:   // I think these are the permanent bouncy pegs that never pop
+                    Log.LogDebug("BOUNCER");
+                    RunVibrate(0.4);
+                    break;
+                case Peg.PegType.GOLD:      // I think this only applies to the special gold pegs, not the regular ones
+                    Log.LogDebug("GOLD");
+                    RunVibrate(0.8);
+                    break;
+                case Peg.PegType.BOMB:
+                    if (peg.GetType() == typeof(Bomb))
+                    {
+                        Bomb bomb = (Bomb)peg;
+                        if (bomb.detonatedThisTurn)     // Not sure this actually works now, needs further debugging
+                        {
+                            Log.LogDebug("Bomb EXPLODE");
+                            RunVibrate(0.8);
+                        }
+                        else
+                        {
+                            Log.LogDebug("Bomb First Hit");
+                            RunVibrate(0.6);
+                        }
+                    }
+                    break;
+                case Peg.PegType.RESET:     // The green R pegs for resetting the board
+                    Log.LogDebug("RESET");
+                    RunVibrate(0.6);
+                    break;
+                default:
+                    Log.LogDebug("OTHER PEG TYPE: " + peg.pegType.ToString());
+                    RunVibrate(0.4);
+                    break;
+            }
+        }
+
+        private static void HandlePegHit(Peg.PegType pegType, Peg peg)
+        {
+            Log.LogDebug("Event logged PegType " + pegType);
+            EvaluatePeg(peg, pegType);
+        }
+
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -116,7 +116,7 @@ namespace PeglinCore
                     break;
                 case Peg.PegType.CRIT:      // Yellow crit peg
                     Log.LogDebug("CRIT");
-                    RunVibrate(0.8);
+                    RunVibrate(0.9);
                     break;
                 case Peg.PegType.DULL:      // I think these are the gray pegs that don't pop on hit, from certain enemies
                     Log.LogDebug("DULL");
@@ -128,21 +128,21 @@ namespace PeglinCore
                     break;
                 case Peg.PegType.GOLD:      // I think this only applies to the special gold pegs, not the regular ones
                     Log.LogDebug("GOLD");
-                    RunVibrate(0.8);
+                    RunVibrate(0.7);
                     break;
                 case Peg.PegType.BOMB:
                     if (peg.GetType() == typeof(Bomb))
                     {
                         Bomb bomb = (Bomb)peg;
-                        if (bomb.detonatedThisTurn)     // Not sure this actually works now, needs further debugging
+                        if (bomb.detonatedThisTurn)     // Pretty sure this doesn't actually work and always goes to the "first hit" branch
                         {
                             Log.LogDebug("Bomb EXPLODE");
-                            RunVibrate(0.8);
+                            RunVibrate(1.0);
                         }
                         else
                         {
                             Log.LogDebug("Bomb First Hit");
-                            RunVibrate(0.6);
+                            RunVibrate(0.9);
                         }
                     }
                     break;


### PR DESCRIPTION
Moves the handler to Peg.OnPegHit, and checks the peg type to trigger different vibrate levels based on peg type

The peg types and values are:

- 40%: Regular
- 80%: Crit (yellow exclamation)
- 30%: Dull (the washed-out ones that don't pop and give very little bounce)
- 40%: Bouncer (the permanent ones that bounce the ball hard but never pop)
- 70%: Gold (pretty sure this is only the special gold ones that look like coins)
- 90%: Bomb (I tried to have different values for 1st hit vs 2nd hit, but it doesn't work as is and I don't have time to investigate)
- 60%: Reset (the green R)